### PR TITLE
Update iOS-keychain-cheat-sheet.md

### DIFF
--- a/iOS/iOS-keychain-cheat-sheet.md
+++ b/iOS/iOS-keychain-cheat-sheet.md
@@ -10,6 +10,6 @@
 
 * Access Control Lists are not available in iOS or to macOS apps that use the iCloud keychain. For keychain item sharing in those environments, use Access Groups instead.
 
-* Keychain does store values after we uninstall the app.
+* Before iOS 10.3, as an effect of the implementation, Keychain does store values after we uninstall the app.
 
 The content is from [Apple Keychain Services Programming Guide.](https://developer.apple.com/library/content/documentation/Security/Conceptual/keychainServConcepts/01introduction/introduction.html#//apple_ref/doc/uid/TP30000897-CH203-TP1)


### PR DESCRIPTION
Apparently the storage of the keychain values after uninstalling the app are not a feature and it's behavior has now changed on 10.3 with the keychain values being remove after uninstalling the app. See more: https://forums.developer.apple.com/thread/72271